### PR TITLE
Update site base URL and add root homepage

### DIFF
--- a/content/HomePage.md
+++ b/content/HomePage.md
@@ -1,5 +1,0 @@
----
-{"publish":true,"created":"2025-11-08T12:27:28.000+08:00","modified":"2025-11-08T12:27:28.000+08:00","cssclasses":""}
----
-
-https://github.com/chenghui03

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,7 @@
+---
+{"title":"Home","publish":true,"created":"2025-11-08T12:27:28.000+08:00","modified":"2025-11-08T12:27:28.000+08:00","aliases":["HomePage"],"cssclasses":""}
+---
+
+# Welcome to ch blog
+
+Explore notes and experiments. View the source on [GitHub](https://github.com/chenghui03/chenghui03.github.io).

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -16,7 +16,7 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     locale: "en-US",
-    baseUrl: "chenghui03.github.io/HomePage",
+    baseUrl: "https://chenghui03.github.io",
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "modified",
     theme: {
@@ -89,7 +89,7 @@ const config: QuartzConfig = {
       Plugin.Favicon(),
       Plugin.NotFoundPage(),
       // Comment out CustomOgImages to speed up build time
-      Plugin.CustomOgImages(),
+      // Plugin.CustomOgImages(),
     ],
   },
 }


### PR DESCRIPTION
## Summary
- point the Quartz base URL to the GitHub Pages root and disable CustomOgImages for consistent local builds
- add a root `content/index.md` homepage and alias redirect from the old `HomePage` path

## Testing
- npx quartz build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935296d405c8321b041484e8185e917)