### PR TITLE
Add configurable comment and reaction embeds

### DIFF
--- a/docs/features/comments.md
+++ b/docs/features/comments.md
@@ -30,27 +30,26 @@ After entering both your repository and selecting the discussion category, Giscu
 
 ![[giscus-results.png]]
 
-Finally, in `quartz.layout.ts`, edit the `afterBody` field of `sharedPageComponents` to include the following options but with the values you got from above:
+Quartz reads these values from environment variables at build time, so you can keep secrets out of version control. Set the following variables in your `.env` file or CI pipeline:
 
-```ts title="quartz.layout.ts"
-afterBody: [
-  Component.Comments({
-    provider: 'giscus',
-    options: {
-      // from data-repo
-      repo: 'jackyzha0/quartz',
-      // from data-repo-id
-      repoId: 'MDEwOlJlcG9zaXRvcnkzODcyMTMyMDg',
-      // from data-category
-      category: 'Announcements',
-      // from data-category-id
-      categoryId: 'DIC_kwDOFxRnmM4B-Xg6',
-      // from data-lang
-      lang: 'en'
-    }
-  }),
-],
+```bash
+GISCUS_REPO="owner/repo"
+GISCUS_REPO_ID="your_repo_id"
+GISCUS_CATEGORY="Announcements"
+GISCUS_CATEGORY_ID="your_category_id"
+GISCUS_LANG="en"
+
+# Optional tweaks
+GISCUS_MAPPING="pathname"           # defaults to pathname
+GISCUS_STRICT="true"                # enable strict title matching
+GISCUS_REACTIONS_ENABLED="true"     # surface reactions in the thread
+GISCUS_INPUT_POSITION="bottom"      # or "top"
+GISCUS_LIGHT_THEME="light"          # custom giscus themes
+GISCUS_DARK_THEME="dark"
+GISCUS_THEME_URL="https://example.com/static/giscus"
 ```
+
+With the variables set, Quartz will automatically render the Giscus widget on content pages (non-index, non-tag pages). No layout edits are required unless you want to swap providers or change ordering.
 
 ### Customization
 
@@ -131,3 +130,24 @@ title: Comments disabled here!
 comments: false
 ---
 ```
+
+## Likes & Reactions (Waline)
+
+Quartz also includes an out-of-the-box reactions widget powered by [Waline](https://waline.js.org/). It renders only on content pages and will skip tag or index listings.
+
+1. Prepare a Waline server (for example, using Vercel, Cloudflare Workers, or your own host) and note its public URL.
+2. Provide the server details via environment variables before building the site:
+
+```bash
+WALINE_SERVER_URL="https://your-waline.example.com"
+
+# Optional settings
+WALINE_REACTIONS="👍,🎉,💡,❤️,🤔"   # custom reaction set
+WALINE_EMOJI="https://unpkg.com/@waline/emojis@1.1.0/weibo"  # comma-separated emoji CDN links
+WALINE_DARK_SELECTOR="html[data-theme='dark']"               # follow your dark selector
+WALINE_LANG="en"
+# Provide a JSON string for locale overrides if needed
+WALINE_LOCALE='{"reactionTitle": "Did you enjoy this post?"}'
+```
+
+If you want to disable the reactions bar for a single page, add `reactions: false` in its frontmatter (similar to the `comments` flag).

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -1,11 +1,83 @@
 import { PageLayout, SharedLayout } from "./quartz/cfg"
+import { QuartzComponentProps } from "./quartz/components/types"
 import * as Component from "./quartz/components"
+
+const isContentPage = (page: QuartzComponentProps) => {
+  const slug = page.fileData.slug ?? ""
+  return !(slug === "index" || slug.startsWith("tags/") || slug.endsWith("/index"))
+}
+
+const toBool = (value: string | undefined, fallback: boolean) => {
+  if (typeof value === "undefined") return fallback
+  return ["1", "true", "yes"].includes(value.toLowerCase())
+}
+
+const toList = (value: string | undefined) =>
+  value
+    ?.split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+
+const safeJson = <T,>(value: string | undefined): T | undefined => {
+  if (!value) return undefined
+  try {
+    return JSON.parse(value) as T
+  } catch (error) {
+    console.warn("Failed to parse JSON from configuration", error)
+    return undefined
+  }
+}
+
+const commentsOptions = {
+  provider: "giscus" as const,
+  options: {
+    repo: (process.env.GISCUS_REPO ?? "") as `${string}/${string}`,
+    repoId: process.env.GISCUS_REPO_ID ?? "",
+    category: process.env.GISCUS_CATEGORY ?? "Announcements",
+    categoryId: process.env.GISCUS_CATEGORY_ID ?? "",
+    mapping: (process.env.GISCUS_MAPPING as
+      | "url"
+      | "title"
+      | "og:title"
+      | "specific"
+      | "number"
+      | "pathname") ?? "pathname",
+    strict: toBool(process.env.GISCUS_STRICT, true),
+    reactionsEnabled: toBool(process.env.GISCUS_REACTIONS_ENABLED, true),
+    inputPosition: (process.env.GISCUS_INPUT_POSITION as "top" | "bottom" | undefined) ?? "bottom",
+    lightTheme: process.env.GISCUS_LIGHT_THEME,
+    darkTheme: process.env.GISCUS_DARK_THEME,
+    themeUrl: process.env.GISCUS_THEME_URL,
+    lang: process.env.GISCUS_LANG ?? "en",
+  },
+}
+
+const reactionsOptions = {
+  provider: "waline" as const,
+  options: {
+    serverURL: process.env.WALINE_SERVER_URL ?? "",
+    reaction: toList(process.env.WALINE_REACTIONS),
+    emoji: toList(process.env.WALINE_EMOJI),
+    locale: safeJson<Record<string, unknown>>(process.env.WALINE_LOCALE),
+    dark: process.env.WALINE_DARK_SELECTOR,
+    lang: process.env.WALINE_LANG,
+  },
+}
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
-  afterBody: [],
+  afterBody: [
+    Component.ConditionalRender({
+      component: Component.Reactions(reactionsOptions),
+      condition: isContentPage,
+    }),
+    Component.ConditionalRender({
+      component: Component.Comments(commentsOptions),
+      condition: isContentPage,
+    }),
+  ],
   footer: Component.Footer({
     links: {
       GitHub: "https://github.com/jackyzha0/quartz",

--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -27,11 +27,14 @@ function boolToStringBool(b: boolean): string {
 
 export default ((opts: Options) => {
   const Comments: QuartzComponent = ({ displayClass, fileData, cfg }: QuartzComponentProps) => {
-    // check if comments should be displayed according to frontmatter
+    const slug = fileData.slug ?? ""
+    const isIndexPage = slug === "index" || slug.endsWith("/index") || slug.startsWith("tags/")
     const disableComment: boolean =
       typeof fileData.frontmatter?.comments !== "undefined" &&
       (!fileData.frontmatter?.comments || fileData.frontmatter?.comments === "false")
-    if (disableComment) {
+    const isConfigComplete =
+      opts.options.repo && opts.options.repoId && opts.options.category && opts.options.categoryId
+    if (disableComment || isIndexPage || !isConfigComplete) {
       return <></>
     }
 
@@ -42,7 +45,7 @@ export default ((opts: Options) => {
         data-repo-id={opts.options.repoId}
         data-category={opts.options.category}
         data-category-id={opts.options.categoryId}
-        data-mapping={opts.options.mapping ?? "url"}
+        data-mapping={opts.options.mapping ?? "pathname"}
         data-strict={boolToStringBool(opts.options.strict ?? true)}
         data-reactions-enabled={boolToStringBool(opts.options.reactionsEnabled ?? true)}
         data-input-position={opts.options.inputPosition ?? "bottom"}

--- a/quartz/components/Reactions.tsx
+++ b/quartz/components/Reactions.tsx
@@ -1,0 +1,60 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { classNames } from "../util/lang"
+// @ts-ignore
+import script from "./scripts/reactions.inline"
+import style from "./styles/reactions.scss"
+
+type WalineReactions = string[]
+
+type Options = {
+  provider: "waline"
+  options: {
+    serverURL: string
+    dark?: string
+    lang?: string
+    reaction?: WalineReactions
+    emoji?: string[]
+    locale?: Record<string, unknown>
+  }
+}
+
+const defaultReactions: WalineReactions = ["👍", "🎉", "💡", "❤️", "🤔"]
+
+export default ((opts: Options) => {
+  const Reactions: QuartzComponent = ({ displayClass, fileData, cfg }: QuartzComponentProps) => {
+    const slug = fileData.slug ?? ""
+    const isIndexPage = slug === "index" || slug.endsWith("/index") || slug.startsWith("tags/")
+    const disableReactions: boolean =
+      typeof fileData.frontmatter?.reactions !== "undefined" &&
+      (!fileData.frontmatter?.reactions || fileData.frontmatter?.reactions === "false")
+
+    if (disableReactions || isIndexPage || !opts.options.serverURL) {
+      return <></>
+    }
+
+    const lang = fileData.frontmatter?.lang ?? opts.options.lang ?? cfg.locale ?? "en"
+    const reactionChoices = opts.options.reaction ?? defaultReactions
+
+    return (
+      <div class={classNames(displayClass, "reactions")}>
+        <div
+          class="waline-reaction-wrapper"
+          data-server-url={opts.options.serverURL}
+          data-lang={lang}
+          data-path={`/${slug}`}
+          data-dark={opts.options.dark ?? "html[data-theme='dark']"}
+          data-reaction={JSON.stringify(reactionChoices)}
+          data-emoji={opts.options.emoji ? JSON.stringify(opts.options.emoji) : undefined}
+          data-locale={opts.options.locale ? JSON.stringify(opts.options.locale) : undefined}
+        >
+          <div class="waline-reaction"></div>
+        </div>
+      </div>
+    )
+  }
+
+  Reactions.css = style
+  Reactions.afterDOMLoaded = script
+
+  return Reactions
+}) satisfies QuartzComponentConstructor<Options>

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -21,6 +21,7 @@ import MobileOnly from "./MobileOnly"
 import RecentNotes from "./RecentNotes"
 import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
+import Reactions from "./Reactions"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
 
@@ -48,6 +49,7 @@ export {
   NotFound,
   Breadcrumbs,
   Comments,
+  Reactions,
   Flex,
   ConditionalRender,
 }

--- a/quartz/components/scripts/reactions.inline.ts
+++ b/quartz/components/scripts/reactions.inline.ts
@@ -1,0 +1,66 @@
+const WALINE_SCRIPT_SRC = "https://unpkg.com/@waline/client@v3/dist/waline.js"
+const WALINE_STYLE_HREF = "https://unpkg.com/@waline/client@v3/dist/waline.css"
+
+type WalineElement = Omit<HTMLElement, "dataset"> & {
+  dataset: DOMStringMap & {
+    serverUrl: string
+    lang?: string
+    path: string
+    dark?: string
+    reaction?: string
+    emoji?: string
+    locale?: string
+  }
+}
+
+type WalineInstance = {
+  destroy?: () => void
+}
+
+type WalineWindow = Window & {
+  Waline?: {
+    init: (options: Record<string, unknown>) => WalineInstance
+  }
+}
+
+const loadWalineAssets = async () => {
+  if (!document.querySelector("link[data-waline-style]")) {
+    const style = document.createElement("link")
+    style.rel = "stylesheet"
+    style.href = WALINE_STYLE_HREF
+    style.dataset.walineStyle = ""
+    document.head.appendChild(style)
+  }
+
+  if (!(window as WalineWindow).Waline) {
+    await import(/* @vite-ignore */ WALINE_SCRIPT_SRC)
+  }
+}
+
+const renderReactions = async () => {
+  const container = document.querySelector(".waline-reaction-wrapper") as WalineElement
+  if (!container) return
+
+  await loadWalineAssets()
+
+  const waline = (window as WalineWindow).Waline?.init({
+    el: container.querySelector(".waline-reaction"),
+    serverURL: container.dataset.serverUrl,
+    lang: container.dataset.lang,
+    dark: container.dataset.dark,
+    reaction: container.dataset.reaction ? JSON.parse(container.dataset.reaction) : true,
+    emoji: container.dataset.emoji ? JSON.parse(container.dataset.emoji) : undefined,
+    locale: container.dataset.locale ? JSON.parse(container.dataset.locale) : undefined,
+    path: container.dataset.path,
+    comment: false,
+    pageview: true,
+  })
+
+  if (waline) {
+    window.addCleanup(() => waline.destroy?.())
+  }
+}
+
+document.addEventListener("nav", () => {
+  renderReactions()
+})

--- a/quartz/components/styles/reactions.scss
+++ b/quartz/components/styles/reactions.scss
@@ -1,0 +1,7 @@
+.reactions {
+  margin-top: 1.5rem;
+
+  .waline-reaction-wrapper {
+    padding: 0.75rem 0;
+  }
+}


### PR DESCRIPTION
## Summary
- wire the comments area to a configurable giscus embed and limit rendering to content pages
- add a Waline-based reactions/likes component with SPA and dark-mode support
- document environment variables for configuring both embeds

## Testing
- npm run check *(fails: existing Prettier formatting issues in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935297e75f08321b6a15caaaab43d8b)